### PR TITLE
Allow for users to pass modules when instantiating a package set

### DIFF
--- a/pure.nix
+++ b/pure.nix
@@ -27,6 +27,9 @@
 , # Allow a configuration attribute set to be passed in as an argument.
   config ? {}
 
+, # Allow for users to pass modules for the evaluation of pkgs.config
+  modules ? []
+
 , # List of overlays layers used to extend Nixpkgs.
   overlays ? []
 
@@ -93,7 +96,7 @@ in let
         _file = "nixpkgs.config";
         config = config1;
       })
-    ];
+    ] ++ modules;
     class = "nixpkgsConfig";
   };
 


### PR DESCRIPTION
For https://github.com/jonringer/language-specific-config-overlays-proposal, it will likely be necessary to compose `overlays.<language>` in a reasonable way. Although this can be done with continuation passing, using nix modules seems like a more sane way to allow users to configure this.